### PR TITLE
[PKG-2514] mashumaro 3.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,6 @@ requirements:
   run:
     - python
     - typing-extensions >=4.1.0
-    # Extra dependency is required by the downstream package dbt by default https://github.com/dbt-labs/dbt-core/blob/v1.5.3/core/setup.py#L57
-    - msgpack-python >=0.5.6
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
   run:
     - python
     - typing-extensions >=4.1.0
+    # Extra dependency is required by the dependant package dbt https://github.com/dbt-labs/dbt-core/blob/v1.5.3/core/setup.py#L57
+    - msgpack >=0.5.6
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - typing-extensions >=4.1.0
-    # Extra dependency is required by the dependant package dbt https://github.com/dbt-labs/dbt-core/blob/v1.5.3/core/setup.py#L57
+    # Extra dependency is required by the downstream package dbt by default https://github.com/dbt-labs/dbt-core/blob/v1.5.3/core/setup.py#L57
     - msgpack-python >=0.5.6
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python
     - typing-extensions >=4.1.0
     # Extra dependency is required by the dependant package dbt https://github.com/dbt-labs/dbt-core/blob/v1.5.3/core/setup.py#L57
-    - msgpack >=0.5.6
+    - msgpack-python >=0.5.6
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,28 +1,27 @@
 {% set name = "mashumaro" %}
-{% set version = "3.8.1" %}
-
+{% set version = "3.6" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/mashumaro-{{ version }}.tar.gz
-  sha256: 8bae8b25e2287b75094655b8ba8635f34016c09ca16498188f2f3b198d88b7ef
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ceb3de53029219bbbb0385ca600b59348dcd14e0c68523986c6d51889ad338f5
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - setuptools
+    - wheel
   run:
-    # Check for dependency changes at:
-    # <https://github.com/Fatal1ty/mashumaro/blob/v{{ version }}/setup.py>
-    - python >=3.7
+    - python
     - typing-extensions >=4.1.0
 
 test:
@@ -30,15 +29,20 @@ test:
     - mashumaro
     - mashumaro.core
     - mashumaro.mixins
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/Fatal1ty/mashumaro
+  dev_url: https://github.com/Fatal1ty/mashumaro
+  doc_url: https://github.com/Fatal1ty/mashumaro
   summary: Fast serialization framework on top of dataclasses
+  description: |
+    Fast and well tested serialization library on top of dataclasses
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
Changelog: https://github.com/Fatal1ty/mashumaro/releases
License: https://github.com/Fatal1ty/mashumaro/blob/v3.6/LICENSE
Requirements: https://github.com/Fatal1ty/mashumaro/blob/v3.6/setup.py

Actions:
1. Clean up the recipe:
- Remove unused jinja2 variables
- Remove `noarch` python
- Skip `py<38`
- Add flags `--no-deps --no-build-isolation` to `script`
- Add missing `wheel` to `host`
- Fix `python` in `host` and `run`
2. Add an extra dependency `msgpack-python >=0.5.6 `that is **required** by the downstream package `dbt` by default https://github.com/dbt-labs/dbt-core/blob/v1.5.3/core/setup.py#L57
3. Add dev and doc urls
4. Add `license_family`
5. Add `description`

Notes:
- `dbt 1.5.3` package requires `mashumaro ==3.6` https://github.com/dbt-labs/dbt-core/blob/v1.5.3/core/setup.py#L57.
- As this is a **new** feedstock forked from the conda-forge it had the latest version 3.8.1 but we need v3.6. 