### PR TITLE
PKG-15966: mashumaro 3.21 -> 3.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mashumaro" %}
-{% set version = "3.21" %}
+{% set version = "3.14" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9bc53b0c7dbed0be80e3ccc3efe1d621ce146b4b7a673ec41ba001a417f2c4b4
+  sha256: 5ef6f2b963892cbe9a4ceb3441dfbea37f8c3412523f25d42e9b3a7186555f1d
 
 build:
   number: 0
@@ -18,10 +18,10 @@ requirements:
   host:
     - pip
     - python
-    - setuptools >=77.0
+    - setuptools
   run:
     - python
-    - typing-extensions >=4.14.0
+    - typing-extensions >=4.1.0
   run_constrained:
     # msgpack
     - msgpack-python >=0.5.6
@@ -56,7 +56,6 @@ test:
     - mashumaro.jsonschema.annotations
     - mashumaro.jsonschema.dialects
     - mashumaro.jsonschema.models
-    - mashumaro.jsonschema.plugins
     - mashumaro.jsonschema.schema
     - mashumaro.mixins
     - mashumaro.mixins.dict
@@ -73,7 +72,7 @@ test:
     - pytest >=6.2.1
     - pytest-mock >=3.5.1
     - msgpack-python >=0.5.6
-    - orjson >=3.10.10
+    - orjson
     - tomli-w >=1.0
     - pyyaml >=3.13
     - ciso8601 >=2.1.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,8 +66,9 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - PYTHONPATH=. pytest -v --import-mode=importlib --ignore=tests/test_pep_695.py --ignore=tests/test_generics_pep_695.py tests  # [py<312]
-    - PYTHONPATH=. pytest -v --import-mode=importlib tests  # [py>=312]
+    - python -c "open('tests/__init__.py', 'w').close()"
+    - pytest -v --ignore=tests/test_pep_695.py --ignore=tests/test_generics_pep_695.py tests  # [py<312]
+    - pytest -v tests  # [py>=312]
   requires:
     - pip
     - pytest >=6.2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,8 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v tests
+    - pytest -v --import-mode=importlib --ignore=tests/test_pep_695.py --ignore=tests/test_generics_pep_695.py tests  # [py<312]
+    - pytest -v --import-mode=importlib tests  # [py>=312]
   requires:
     - pip
     - pytest >=6.2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,27 @@ requirements:
     # yaml
     - pyyaml >=3.13
 
+# The 3.14 sdist omits tests/entities.py, tests/utils.py, and tests/conftest.py,
+# so tests that import from those helpers must be skipped.
+{% set tests_missing_helpers = [
+  "--ignore=tests/test_config.py",
+  "--ignore=tests/test_data_types.py",
+  "--ignore=tests/test_dialect.py",
+  "--ignore=tests/test_generics.py",
+  "--ignore=tests/test_generics_pep_695.py",
+  "--ignore=tests/test_json.py",
+  "--ignore=tests/test_literal.py",
+  "--ignore=tests/test_meta.py",
+  "--ignore=tests/test_metadata_options.py",
+  "--ignore=tests/test_pep_563.py",
+  "--ignore=tests/test_types.py",
+  "--ignore=tests/test_union.py",
+] %}
+# test_pep_695.py uses the PEP 695 `type` keyword syntax, available only in Python 3.12+.
+{% set tests_pep695_syntax = [
+  "--ignore=tests/test_pep_695.py",
+] %}
+
 test:
   source_files:
     - tests
@@ -66,9 +87,8 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - python -c "open('tests/__init__.py', 'w').close()"
-    - pytest -v --ignore=tests/test_pep_695.py --ignore=tests/test_generics_pep_695.py tests  # [py<312]
-    - pytest -v tests  # [py>=312]
+    - pytest -v {{ (tests_missing_helpers + tests_pep695_syntax) | join(" ") }} tests  # [py<312]
+    - pytest -v {{ tests_missing_helpers | join(" ") }} tests  # [py>=312]
   requires:
     - pip
     - pytest >=6.2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,8 +66,8 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v --import-mode=importlib --ignore=tests/test_pep_695.py --ignore=tests/test_generics_pep_695.py tests  # [py<312]
-    - pytest -v --import-mode=importlib tests  # [py>=312]
+    - PYTHONPATH=. pytest -v --import-mode=importlib --ignore=tests/test_pep_695.py --ignore=tests/test_generics_pep_695.py tests  # [py<312]
+    - PYTHONPATH=. pytest -v --import-mode=importlib tests  # [py>=312]
   requires:
     - pip
     - pytest >=6.2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,11 @@ requirements:
     # yaml
     - pyyaml >=3.13
 
-# The 3.14 sdist omits tests/entities.py, tests/utils.py, and tests/conftest.py,
-# so tests that import from those helpers must be skipped.
+# The 3.14 PyPI sdist does not ship tests/entities.py, tests/utils.py, or
+# tests/conftest.py (they exist in the GitHub repo but are excluded from the
+# tarball manifest). Any test file that imports from those helpers fails at
+# collection time with ModuleNotFoundError. This was fixed in the 3.21 sdist,
+# which includes them — the 3.21 recipe runs pytest with no ignores at all.
 {% set tests_missing_helpers = [
   "--ignore=tests/test_config.py",
   "--ignore=tests/test_data_types.py",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,11 +76,11 @@ test:
     - mashumaro.dialect
     - mashumaro.exceptions
     - mashumaro.helper
-    - mashumaro.jsonschema
-    - mashumaro.jsonschema.annotations
-    - mashumaro.jsonschema.dialects
-    - mashumaro.jsonschema.models
-    - mashumaro.jsonschema.schema
+    - mashumaro.jsonschema         # [py<314]
+    - mashumaro.jsonschema.annotations  # [py<314]
+    - mashumaro.jsonschema.dialects     # [py<314]
+    - mashumaro.jsonschema.models       # [py<314]
+    - mashumaro.jsonschema.schema       # [py<314]
     - mashumaro.mixins
     - mashumaro.mixins.dict
     - mashumaro.mixins.msgpack


### PR DESCRIPTION
## Links
- Jira: https://anaconda.atlassian.net/browse/PKG-15966
- dev_url: https://github.com/Fatal1ty/mashumaro/tree/v3.14
- conda-forge: https://github.com/conda-forge/mashumaro-feedstock
- PyPI: https://pypi.org/project/mashumaro/3.14
- PyPI Inspector: https://inspector.pypi.io/project/mashumaro/3.14

## Changes
- downgrade mashumaro 3.21 → 3.14 (versioned feedstock for dbt-adapters >=3.9,<3.15)
- relax typing-extensions pin to >=4.1.0
- remove setuptools version pin
- remove mashumaro.jsonschema.plugins import (not present in 3.14)
- relax orjson test requirement

## Notes
- PR targets `main-3.14` branch (versioned feedstock, not master)